### PR TITLE
GetConstructorName cannot handle Angular

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,6 +12,9 @@ export const getConstructorName = (obj: { constructor: { name: string } } | unde
   try {
     return obj!.constructor.name;
   } catch (e) {}
+  try {
+    return obj.__zone_symbol__originalInstance.constructor.name;
+  } catch (e) {}
   return '';
 };
 


### PR DESCRIPTION
This is a solution for, and should close #97

Angular has zone.js and the constructor names cannot be fetched from there